### PR TITLE
Adds a simple approach for querying by iterating over the 2d bouding box on a coarse grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,78 @@ I have generated the file `berlin-latest-hydrants.parquet` and have a GitHub Pag
 python3 index.py berlin-latest.osm.pbf -o berlin-latest-hydrants.parquet
 ```
 
-This means we can make queries against it with DuckDB for testing purpose
+This means we can make queries against the remotely Parquet file with DuckDB
 
 ```sql
-select
-  z, lng, lat
-from
+SELECT
+  lng, lat
+FROM
   'https://daniel-j-h.github.io/zindex/berlin-latest-hydrants.parquet'
-limit 5;
+WHERE
+  z IN (3771320898, 3771320904)
+  AND lng BETWEEN 2307450897 AND 2307489074
+  AND lat BETWEEN 3400700224 AND 3400740787
 ```
 
-|     z      |    lng     |    lat     |
-|-----------:|-----------:|-----------:|
-| 3771284411 | 2304120872 | 3397430539 |
-| 3771284411 | 2304121287 | 3397430532 |
-| 3771284411 | 2304139434 | 3397429778 |
-| 3771284414 | 2304154532 | 3397429503 |
-| 3771296433 | 2307284277 | 3397201896 |
+```
+┌────────────┬────────────┐
+│ lng        ┆ lat        │
+╞════════════╪════════════╡
+│ 2307451925 ┆ 3400717306 │
+│ 2307467484 ┆ 3400723676 │
+│ 2307452687 ┆ 3400716838 │
+│ 2307471065 ┆ 3400728515 │
+│ 2307473447 ┆ 3400717329 │
+│ 2307462469 ┆ 3400727098 │
+│ 2307458019 ┆ 3400734922 │
+└────────────┴────────────┘
+```
 
+or even from a browser e.g. with [DuckDB-WASM](https://www.npmjs.com/package/@duckdb/duckdb-wasm).
+Try out the query above in a DuckDB-WASM Shell [here](https://shell.duckdb.org/#queries=v0,SELECT-lng%2C-lat-FROM-'https%3A%2F%2Fdaniel%20j%20h.github.io%2Fzindex%2Fberlin%20latest%20hydrants.parquet'-WHERE-z-IN-(3771320898%2C3771320904)-AND-lng-BETWEEN-2307450897-AND-2307489074-AND-lat-BETWEEN-3400700224-AND-3400740787~).
+
+Note that in the query above the `WHERE z IN (..)` makes the query efficient since the parquet file is sorted by Z values.
+The clauses `AND lng BETWEEN lngmin AND lngmax` and `AND lat BETWEEN latmin AND latmax` then run subsequent filtering steps on all items contained within the specific Z values.
+The two implementation approaches described below show how to tune the query for the first and second filtering step for your use case.
 
 ## How It Works
 
-We sort 2d points along a Z-order space-filling curve and use an optimization ("BIGMIN") to skip over irrelevant data when walking the curve.
+We sort 2d points along a Z-order space-filling curve and query for them efficiently.
+
+Then there are two approaches:
+Both make efficient byte-range requests against a single Parquet file.
+
+
+### Simple Approach
+
+We implement a simple approach after talking to [Sarah Hoffmann](https://github.com/lonvia) pointing out use cases for which this approach is good enough.
+The simple approach works as follows:
+With a bounding box query, discretize the min and max locations on a 16-bit grid and simply iterate over all possible values.
+
+```python
+for lng16 in range(lngmin16, lngmax16):
+    for lat16 in range(latmin16, latmax16):
+        z32 = zencode32(lng16, lat16)
+```
+
+This is simple to implement on the query side and should work well for use cases e.g. where the data is not too dense so that a single 16-bit grid cell contains a large amount of items to subsequently filter.
+
+
+### BIGMIN Optimization
+
+We use an optimization ("BIGMIN") to skip over irrelevant data when walking the curve.
+The BIGMIN approach works as follows:
+With a bounding box query, get the Z-Curve value for its min and max location.
+Then walk this linear range of Z values and use the BIGMIN optimization to skip over irrelevant data.
+
+```python
+z = zmin
+
+while z < zmax:
+    z = zindex.next_zorder_index(z)
+```
+
+This is more difficult to implement on the query side but generalizes well for more use cases.
 
 | Z-curve with query bounding box | Z-curve with BIGMIN skipping |
 |-|-|


### PR DESCRIPTION
@lonvia check this out! :pray:  Based on our conversation I added a simple query that runs over all x over all y when we discretize them on a 16-bit grid. I think this could be Good Enough for most use cases folks have where the query bounding box is rather small and especially the dataset is not too dense. If it's too dense (too many items within a 16-bit grid cell) then it gets expensive to do the post-filtering.

I added an explanation for both versions and a quick description of where and how they differ. Check out [the readme](https://github.com/daniel-j-h/zindex?tab=readme-ov-file#zindex).

[Here is an example query](https://shell.duckdb.org/#queries=v0,SELECT-lng%2C-lat-FROM-'https%3A%2F%2Fdaniel%20j%20h.github.io%2Fzindex%2Fberlin%20latest%20hydrants.parquet'-WHERE-z-IN-(3771320898%2C3771320904)-AND-lng-BETWEEN-2307450897-AND-2307489074-AND-lat-BETWEEN-3400700224-AND-3400740787~) that runs against the Github hosted parquet file from your browser. Give it a try!
